### PR TITLE
Allow role arns

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ myFunction:
       TABLE_NAME: my-table
     region: us-east-1
 
+    # if you want to use a specific role pass an arn
+    role: arn:XXX
+
     # if you'd like to include any shims
     shims:
       - ../shims/shim.js 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ myFunction:
     region: us-east-1
 
     # if you want to use a specific role pass an arn
-    roleArn: arn:XXX
+    role: 
+      arn: arn:XXX
 
     # if you'd like to include any shims
     shims:

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ myFunction:
     region: us-east-1
 
     # if you want to use a specific role pass an arn
-    role: arn:XXX
+    roleArn: arn:XXX
 
     # if you'd like to include any shims
     shims:

--- a/serverless.js
+++ b/serverless.js
@@ -63,8 +63,7 @@ class AwsLambda extends Component {
     const awsIamRole = await this.load('@serverless/aws-iam-role')
 
     // If no role exists, create a default role
-    this.state.iamIsStatic = true
-    if (!config.role && !config.role.arn) {
+    if (!config.role) {
       this.state.iamIsStatic = false
       this.context.debug(`No role provided for lambda ${config.name}.`)
 
@@ -76,6 +75,9 @@ class AwsLambda extends Component {
         region: config.region
       })
       config.role = { arn: outputsAwsIamRole.arn }
+    } else {
+      this.state.iamIsStatic = true
+      config.role = { arn: config.role }
     }
 
     if (

--- a/serverless.js
+++ b/serverless.js
@@ -24,7 +24,7 @@ const outputsList = [
   'handler',
   'runtime',
   'env',
-  'role',
+  'roleArn',
   'layer',
   'arn',
   'region'
@@ -63,7 +63,8 @@ class AwsLambda extends Component {
     const awsIamRole = await this.load('@serverless/aws-iam-role')
 
     // If no role exists, create a default role
-    if (!config.role) {
+    this.state.iamIsStatic = true
+    if (!config.roleArn) {
       this.state.iamIsStatic = false
       this.context.debug(`No role provided for lambda ${config.name}.`)
 
@@ -74,10 +75,7 @@ class AwsLambda extends Component {
         },
         region: config.region
       })
-      config.role = { arn: outputsAwsIamRole.arn }
-    } else {
-      this.state.iamIsStatic = true
-      config.role = { arn: config.role }
+      config.roleArn = outputsAwsIamRole.arn
     }
 
     if (

--- a/serverless.js
+++ b/serverless.js
@@ -24,7 +24,7 @@ const outputsList = [
   'handler',
   'runtime',
   'env',
-  'roleArn',
+  'role',
   'layer',
   'arn',
   'region'
@@ -64,7 +64,7 @@ class AwsLambda extends Component {
 
     // If no role exists, create a default role
     this.state.iamIsStatic = true
-    if (!config.roleArn) {
+    if (!config.role || !config.role.arn) {
       this.state.iamIsStatic = false
       this.context.debug(`No role provided for lambda ${config.name}.`)
 
@@ -75,7 +75,7 @@ class AwsLambda extends Component {
         },
         region: config.region
       })
-      config.roleArn = outputsAwsIamRole.arn
+      config.role = { arn: outputsAwsIamRole.arn }
     }
 
     if (

--- a/serverless.js
+++ b/serverless.js
@@ -63,12 +63,9 @@ class AwsLambda extends Component {
     const awsIamRole = await this.load('@serverless/aws-iam-role')
 
     // If no role exists, create a default role
-    if (config.role && config.role.arn) {
-      this.state.iamIsStatic = true
-    } else if (config.role) {
-      const outputsAwsIamRole = await awsIamRole(config.role)
-      config.role = { arn: outputsAwsIamRole.arn }
-    } else {
+    this.state.iamIsStatic = true
+    if (!config.role && !config.role.arn) {
+      this.state.iamIsStatic = false
       this.context.debug(`No role provided for lambda ${config.name}.`)
 
       const outputsAwsIamRole = await awsIamRole({

--- a/utils.js
+++ b/utils.js
@@ -75,7 +75,7 @@ const createLambda = async ({
   description,
   zipPath,
   bucket,
-  role,
+  roleArn,
   layer
 }) => {
   const params = {
@@ -85,7 +85,7 @@ const createLambda = async ({
     Handler: handler,
     MemorySize: memory,
     Publish: true,
-    Role: role.arn,
+    Role: roleArn,
     Runtime: runtime,
     Timeout: timeout,
     Environment: {
@@ -118,7 +118,7 @@ const updateLambdaConfig = async ({
   runtime,
   env,
   description,
-  role,
+  roleArn,
   layer
 }) => {
   const functionConfigParams = {
@@ -126,7 +126,7 @@ const updateLambdaConfig = async ({
     Description: description,
     Handler: handler,
     MemorySize: memory,
-    Role: role.arn,
+    Role: roleArn,
     Runtime: runtime,
     Timeout: timeout,
     Environment: {
@@ -173,9 +173,7 @@ const getLambda = async ({ lambda, name }) => {
       description: res.Description,
       timeout: res.Timeout,
       runtime: res.Runtime,
-      role: {
-        arn: res.Role
-      },
+      role: res.Role,
       handler: res.Handler,
       memory: res.MemorySize,
       hash: res.CodeSha256,
@@ -220,9 +218,8 @@ const getPolicy = async ({ name, region, accountId }) => {
 }
 
 const configChanged = (prevLambda, lambda) => {
-  const keys = ['description', 'runtime', 'role', 'handler', 'memory', 'timeout', 'env', 'hash']
+  const keys = ['description', 'runtime', 'roleArn', 'handler', 'memory', 'timeout', 'env', 'hash']
   const inputs = pick(keys, lambda)
-  inputs.role = { arn: inputs.role.arn } // remove other inputs.role component outputs
   const prevInputs = pick(keys, prevLambda)
   return not(equals(inputs, prevInputs))
 }

--- a/utils.js
+++ b/utils.js
@@ -75,7 +75,7 @@ const createLambda = async ({
   description,
   zipPath,
   bucket,
-  roleArn,
+  role,
   layer
 }) => {
   const params = {
@@ -85,7 +85,7 @@ const createLambda = async ({
     Handler: handler,
     MemorySize: memory,
     Publish: true,
-    Role: roleArn,
+    Role: role.arn,
     Runtime: runtime,
     Timeout: timeout,
     Environment: {
@@ -118,7 +118,7 @@ const updateLambdaConfig = async ({
   runtime,
   env,
   description,
-  roleArn,
+  role,
   layer
 }) => {
   const functionConfigParams = {
@@ -126,7 +126,7 @@ const updateLambdaConfig = async ({
     Description: description,
     Handler: handler,
     MemorySize: memory,
-    Role: roleArn,
+    Role: role.arn,
     Runtime: runtime,
     Timeout: timeout,
     Environment: {
@@ -218,7 +218,7 @@ const getPolicy = async ({ name, region, accountId }) => {
 }
 
 const configChanged = (prevLambda, lambda) => {
-  const keys = ['description', 'runtime', 'roleArn', 'handler', 'memory', 'timeout', 'env', 'hash']
+  const keys = ['description', 'runtime', 'role', 'handler', 'memory', 'timeout', 'env', 'hash']
   const inputs = pick(keys, lambda)
   const prevInputs = pick(keys, prevLambda)
   return not(equals(inputs, prevInputs))


### PR DESCRIPTION
PR for #10. Now you can pass a role-arn into the role field if you want to use a specific and existing arn. Passing a non-existing role-arn gives you an InvalidParameterValueException, and passing an arn that is not of type role or just a random string gives you a ValidationException. 