### PR TITLE
Support publishing new version

### DIFF
--- a/__mocks__/aws-sdk.js
+++ b/__mocks__/aws-sdk.js
@@ -1,0 +1,44 @@
+const promisifyMock = (mockFn) => {
+  const promise = jest.fn()
+  mockFn.mockImplementation(() => ({
+    promise
+  }))
+
+  return promise
+}
+
+const mockCreateFunction = jest.fn()
+const mockCreateFunctionPromise = promisifyMock(mockCreateFunction)
+
+const mockPublishVersion = jest.fn()
+const mockPublishVersionPromise = promisifyMock(mockPublishVersion)
+
+const mockGetFunctionConfiguration = jest.fn()
+const mockGetFunctionConfigurationPromise = promisifyMock(mockGetFunctionConfiguration)
+
+const mockUpdateFunctionCode = jest.fn()
+const mockUpdateFunctionCodePromise = promisifyMock(mockUpdateFunctionCode)
+
+const mockUpdateFunctionConfiguration = jest.fn()
+const mockUpdateFunctionConfigurationPromise = promisifyMock(mockUpdateFunctionConfiguration)
+
+module.exports = {
+  mockCreateFunction,
+  mockCreateFunctionPromise,
+  mockPublishVersion,
+  mockPublishVersionPromise,
+  mockGetFunctionConfiguration,
+  mockGetFunctionConfigurationPromise,
+  mockUpdateFunctionCode,
+  mockUpdateFunctionCodePromise,
+  mockUpdateFunctionConfiguration,
+  mockUpdateFunctionConfigurationPromise,
+
+  Lambda: jest.fn(() => ({
+    createFunction: mockCreateFunction,
+    publishVersion: mockPublishVersion,
+    getFunctionConfiguration: mockGetFunctionConfiguration,
+    updateFunctionCode: mockUpdateFunctionCode,
+    updateFunctionConfiguration: mockUpdateFunctionConfiguration
+  }))
+}

--- a/__tests__/publishVersion.test.js
+++ b/__tests__/publishVersion.test.js
@@ -1,0 +1,100 @@
+const { createComponent, createTmpDir } = require('../test-utils')
+
+const {
+  mockCreateFunctionPromise,
+  mockPublishVersion,
+  mockPublishVersionPromise,
+  mockGetFunctionConfigurationPromise,
+  mockUpdateFunctionCodePromise,
+  mockUpdateFunctionConfigurationPromise
+} = require('aws-sdk')
+
+const mockIamRole = jest.fn()
+jest.mock('@serverless/aws-iam-role', () =>
+  jest.fn(() => {
+    const iamRole = mockIamRole
+    iamRole.init = () => {}
+    iamRole.default = () => {}
+    iamRole.context = {}
+    return iamRole
+  })
+)
+
+describe('publishVersion', () => {
+  let component
+
+  beforeEach(async () => {
+    mockIamRole.mockResolvedValue({
+      arn: 'arn:aws:iam::123456789012:role/xyz'
+    })
+    mockCreateFunctionPromise.mockResolvedValueOnce({
+      FunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:my-func',
+      CodeSha256: 'LQT0VA='
+    })
+
+    component = await createComponent()
+  })
+
+  it('publishes new version of lambda that was created', async () => {
+    mockGetFunctionConfigurationPromise.mockRejectedValueOnce({ code: 'ResourceNotFoundException' })
+    mockPublishVersionPromise.mockResolvedValueOnce({
+      Version: 'v2'
+    })
+    const tmpFolder = await createTmpDir()
+
+    await component.default({
+      code: tmpFolder
+    })
+
+    const versionResult = await component.publishVersion()
+
+    expect(mockPublishVersion).toBeCalledWith({
+      FunctionName: expect.any(String),
+      CodeSha256: 'LQT0VA='
+    })
+
+    expect(versionResult).toEqual({
+      version: 'v2'
+    })
+  })
+
+  it('publishes new version of lambda that was updated', async () => {
+    mockPublishVersionPromise.mockResolvedValue({
+      Version: 'v2'
+    })
+    mockGetFunctionConfigurationPromise.mockRejectedValueOnce({ code: 'ResourceNotFoundException' })
+    mockGetFunctionConfigurationPromise.mockResolvedValueOnce({
+      FunctionName: 'my-func'
+    })
+    mockUpdateFunctionCodePromise.mockResolvedValueOnce({
+      FunctionName: 'my-func'
+    })
+    mockCreateFunctionPromise.mockResolvedValueOnce({
+      CodeSha256: 'LQT0VA='
+    })
+    mockUpdateFunctionConfigurationPromise.mockResolvedValueOnce({
+      CodeSha256: 'XYZ0VA='
+    })
+
+    const tmpFolder = await createTmpDir()
+
+    await component.default({
+      code: tmpFolder
+    })
+
+    await component.default({
+      code: tmpFolder
+    })
+
+    const versionResult = await component.publishVersion()
+
+    expect(mockPublishVersion).toBeCalledWith({
+      FunctionName: expect.any(String),
+      CodeSha256: 'XYZ0VA=' // compare against the hash received from the function update, *not* create
+    })
+
+    expect(versionResult).toEqual({
+      version: 'v2'
+    })
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  clearMocks: true
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "access": "public"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "lint": "eslint . --fix --cache"
   },
   "author": "Serverless, Inc.",
@@ -28,6 +28,7 @@
     "eslint-config-prettier": "^3.6.0",
     "eslint-plugin-import": "^2.18.0",
     "eslint-plugin-prettier": "^3.1.0",
+    "jest": "^24.9.0",
     "prettier": "^1.18.2"
   }
 }

--- a/test-utils.js
+++ b/test-utils.js
@@ -1,0 +1,23 @@
+const fse = require('fs-extra')
+const path = require('path')
+const os = require('os')
+const LambdaComponent = require('./serverless')
+
+const createTmpDir = () => {
+  return fse.mkdtemp(path.join(os.tmpdir(), 'test-'))
+}
+
+const createComponent = async () => {
+  // create tmp folder to avoid state collisions between tests
+  const tmpFolder = await createTmpDir()
+
+  const component = new LambdaComponent('TestLambda', {
+    stateRoot: tmpFolder
+  })
+
+  await component.init()
+
+  return component
+}
+
+module.exports = { createComponent, createTmpDir }

--- a/utils.js
+++ b/utils.js
@@ -106,7 +106,7 @@ const createLambda = async ({
 
   const res = await lambda.createFunction(params).promise()
 
-  return res.FunctionArn
+  return { arn: res.FunctionArn, hash: res.CodeSha256 }
 }
 
 const updateLambdaConfig = async ({
@@ -140,7 +140,7 @@ const updateLambdaConfig = async ({
 
   const res = await lambda.updateFunctionConfiguration(functionConfigParams).promise()
 
-  return res.FunctionArn
+  return { arn: res.FunctionArn, hash: res.CodeSha256 }
 }
 
 const updateLambdaCode = async ({ lambda, name, zipPath, bucket }) => {


### PR DESCRIPTION
Adds support to publish versions from the Lambda component. This will allow easier integration with the aws-cloudfront component which requires an ARN including the version number. For example:

```js
const lambdaAtEdgeOutputs = await lambda({...});
const lambdaPublishOutputs = await lambda.publishVersion();

await cloudFront({
  ...
  "lambda@edge": {
	"origin-request": `${lambdaAtEdgeOutputs.arn}:${lambdaPublishOutputs.version}`
  }
)
``` 