### PR TITLE
add logs and metrics methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ build/
 env.js
 package-lock.json
 test
+handler.js


### PR DESCRIPTION
This is a first pass at adding experimental logs and metrics methods.

One of the goals is to have standard inputs and outputs across `logs()` and `metrics()` methods across all components.  Here is an attempt at that.