### PR TITLE
chore(lambda-name): Added provision to custom lambda name.

### DIFF
--- a/serverless.js
+++ b/serverless.js
@@ -50,7 +50,7 @@ class AwsLambda extends Component {
 
     const config = mergeDeepRight(defaults, inputs)
 
-    config.name = this.state.name || this.context.resourceId()
+    config.name = this.state.name || config.name || this.context.resourceId()
 
     this.context.debug(
       `Starting deployment of lambda ${config.name} to the ${config.region} region.`


### PR DESCRIPTION
**Context**

It always generates random name even if logical name has been provided. This is because the input name has been ignored.  This PR will give precedence to input name.