### PR TITLE
Fix files being omitted

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -16,7 +16,7 @@ const packDir = async (inputDirPath, outputFilePath, include = [], exclude = [],
     throw new Error('Please provide a valid format. Either a "zip" or a "tar"')
   }
 
-  const patterns = ['**']
+  const patterns = ['**/*']
 
   if (!isNil(exclude)) {
     exclude.forEach((excludedItem) => patterns.push(`!${excludedItem}`))


### PR DESCRIPTION
The glob `'**'` would not match files such as `[...file].js`.

Included files before PR:

```
.file.js
[file].js
file.js
```

Included files after PR:

```
.file.js
[...file].js
[file].js
file.js
```