### PR TITLE
Fix: license SPDX identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint . --fix --cache"
   },
   "author": "Serverless, Inc.",
-  "license": "Apache",
+  "license": "Apache-2.0",
   "dependencies": {},
   "devDependencies": {
     "@serverless/platform-client": "^0.24.0",


### PR DESCRIPTION
This suppresses a warning shown in the terminal.