### PR TITLE
Fix: remove hardcoded runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ inputs:
   memory: 512                    # (optional) lambda memory size.
   timeout: 10                    # (optional) lambda timeout.
   description: My Lambda.        # (optional) lambda description.
+  runtime: 'nodejs14.x'          # (optional) lambda runtime
   env:                           # (optional) env vars.
     FOO: BAR
   roleName: plain-name           # (optional) custom role name.

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,7 +55,7 @@ const prepareInputs = (inputs, instance) => {
     timeout: inputs.timeout || 10,
     src: inputs.src || null,
     handler: inputs.handler || 'handler.handler',
-    runtime: inputs.runtime || 'nodejs12.x',
+    runtime: inputs.runtime || 'nodejs14.x',
     env: inputs.env || {},
     region: inputs.region || 'us-east-1',
     layers: inputs.layers || [],

--- a/src/utils.js
+++ b/src/utils.js
@@ -55,7 +55,7 @@ const prepareInputs = (inputs, instance) => {
     timeout: inputs.timeout || 10,
     src: inputs.src || null,
     handler: inputs.handler || 'handler.handler',
-    runtime: 'nodejs12.x',
+    runtime: inputs.runtime || 'nodejs12.x',
     env: inputs.env || {},
     region: inputs.region || 'us-east-1',
     layers: inputs.layers || [],


### PR DESCRIPTION
As stated in #44 this fix should be all it needs to be able to specify the runtime from the input object.

I also upgraded the default runtime to the new LTS as stated in the official Amazon AWS blog post: https://aws.amazon.com/blogs/compute/node-js-14-x-runtime-now-available-in-aws-lambda/